### PR TITLE
dockerize both parsers and registries

### DIFF
--- a/apps/parsers/mix/.dockerignore
+++ b/apps/parsers/mix/.dockerignore
@@ -1,0 +1,3 @@
+_build
+test
+tmp

--- a/apps/parsers/mix/.gitignore
+++ b/apps/parsers/mix/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 mix-*.tar
 
+/tmp

--- a/apps/parsers/mix/Dockerfile
+++ b/apps/parsers/mix/Dockerfile
@@ -1,0 +1,13 @@
+# build: docker build . -t parsers/mix:latest
+# run: docker run --mount type=bind,source="$(pwd)"/tmp,target=/tmp parsers/mix:latest mix mix.parse [path]
+FROM elixir:1.9-slim
+
+ENV MIX_ENV production
+
+WORKDIR /mix
+COPY . /mix
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix deps.get
+RUN mix compile

--- a/apps/registries/hexpm/.dockerignore
+++ b/apps/registries/hexpm/.dockerignore
@@ -1,0 +1,3 @@
+_build
+fixture
+test

--- a/apps/registries/hexpm/Dockerfile
+++ b/apps/registries/hexpm/Dockerfile
@@ -1,0 +1,13 @@
+# build: docker build . -t registries/hexpm:latest
+# run: docker run registries/hexpm:latest mix hexpm.lookup [package] [version]
+FROM elixir:1.9-slim
+
+ENV MIX_ENV production
+
+WORKDIR /hexpm
+COPY . /hexpm
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix deps.get
+RUN mix compile


### PR DESCRIPTION
- to sandbox the process, since we'll be processing arbitrary user input
- to encapsulate the environment in a reproducable build