### PR TITLE
bugfix: infinite error raised by elm virtual-dom updater

### DIFF
--- a/apps/s12y/assets/elm/src/Layout.elm
+++ b/apps/s12y/assets/elm/src/Layout.elm
@@ -1,10 +1,11 @@
 module Layout exposing (view)
 
 import Browser
-import Component.Svg as Svg exposing (view)
+import Component.Svg as Svg
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Entity exposing (copy)
+import Html.Lazy exposing (lazy)
 
 
 
@@ -14,8 +15,13 @@ import Html.Entity exposing (copy)
 view : { title : String, content : Html msg } -> Browser.Document msg
 view { title, content } =
     { title = title ++ " -- s12y"
-    , body = viewHeader :: content :: [ viewFooter ]
+    , body = svgRoot :: viewHeader :: content :: [ viewFooter ]
     }
+
+
+svgRoot : Html msg
+svgRoot =
+    lazy (\a -> div [ id "svg-root" ] a) []
 
 
 viewHeader : Html msg

--- a/apps/s12y/assets/js/spriteModule.js
+++ b/apps/s12y/assets/js/spriteModule.js
@@ -1,0 +1,46 @@
+/*
+ * from https://github.com/kisenka/svg-sprite-loader/blob/v4.1.6/runtime/browser-sprite.js
+ *
+ * customized to mount to existing dom prepared by elm instead of to body
+ * required to avoid crashing elm virtual dom
+ */
+
+import BrowserSprite from "svg-baker-runtime/src/browser-sprite";
+import domready from "domready";
+
+const spriteNodeId = "__SVG_SPRITE_NODE__";
+const spriteGlobalVarName = "__SVG_SPRITE__";
+const isSpriteExists = !!window[spriteGlobalVarName];
+
+// eslint-disable-next-line import/no-mutable-exports
+let sprite;
+
+if (isSpriteExists) {
+  sprite = window[spriteGlobalVarName];
+} else {
+  sprite = new BrowserSprite({ attrs: { id: spriteNodeId } });
+  window[spriteGlobalVarName] = sprite;
+}
+
+const loadSprite = () => {
+  /**
+   * Check for page already contains sprite node
+   * If found - attach to and reuse it's content
+   * If not - render and mount the new sprite
+   */
+  const existing = document.getElementById(spriteNodeId);
+
+  if (existing) {
+    sprite.attach(existing);
+  } else {
+    sprite.mount("#svg-root");
+  }
+};
+
+if (document.body) {
+  loadSprite();
+} else {
+  domready(loadSprite);
+}
+
+export default sprite;

--- a/apps/s12y/assets/webpack.config.js
+++ b/apps/s12y/assets/webpack.config.js
@@ -63,7 +63,9 @@ module.exports = (env, options) => ({
         use: [
           {
             loader: "svg-sprite-loader",
-            options: {}
+            options: {
+              spriteModule: "./js/spriteModule"
+            }
           },
           "svgo-loader"
         ]


### PR DESCRIPTION
injecting a node in the middle of elm virtual dom will confuse the updater, since it won't be able to figure out what to do with the additional node

to avoid this issue, we prepare a dummy empty div which will be used as mount point for the svg