### PR TITLE
refactor: based work on uuid

### DIFF
--- a/apps/parsers/mix/lib/mix.ex
+++ b/apps/parsers/mix/lib/mix.ex
@@ -2,9 +2,11 @@ defmodule S12y.Parsers.Mix do
   alias S12y.Parsers.Mix.Parser
 
   @doc """
-  Parse arbitrary mix.exs string input and return the list of top-level dependencies defined in it.
+  Parse arbitrary mix.exs file and return the list of top-level dependencies defined in it.
+
+  The file are expected to exist under `/tmp/[id]/mix.exs`.
   """
-  def parse(source) do
-    Parser.start(source)
+  def parse(id) do
+    Parser.start(id)
   end
 end

--- a/apps/parsers/mix/lib/mix/parser.ex
+++ b/apps/parsers/mix/lib/mix/parser.ex
@@ -1,31 +1,20 @@
 defmodule S12y.Parsers.Mix.Parser do
-  def start(source) do
-    initialize(source)
+  def start(id) do
+    initialize(id)
     |> generate_project!
     |> run
   end
 
-  defp initialize(source), do: %{id: generate_id(), source: source}
-  defp generate_id(), do: UUID.uuid4()
+  defp initialize(id), do: %{id: id, path: "/tmp/#{id}"}
 
   defp generate_project!(parser) do
     parser
-    |> create_directory!
     |> copy_parser_script!
-    |> write_mix_exs!
   end
 
   defp run(parser) do
-    {out, 0} = System.cmd("elixir", [script()], cd: directory(parser))
+    {out, 0} = System.cmd("elixir", [script()], cd: parser.path)
     out
-  end
-
-  defp create_directory!(parser) do
-    parser
-    |> directory
-    |> File.mkdir_p!()
-
-    parser
   end
 
   defp copy_parser_script!(parser) do
@@ -33,16 +22,8 @@ defmodule S12y.Parsers.Mix.Parser do
     parser
   end
 
-  defp write_mix_exs!(parser) do
-    File.write!(mix_exs_destination(parser), parser.source)
-    parser
-  end
-
   defp app_name, do: Mix.Project.config()[:app]
-  defp directory(parser), do: Path.join("/tmp", parser.id)
-  defp mix_exs, do: "mix.exs"
-  defp mix_exs_destination(parser), do: Path.join(directory(parser), mix_exs())
   defp parser_template, do: Path.join([:code.priv_dir(app_name()), "templates", "parser.exs"])
   defp script, do: "parser.exs"
-  defp script_destination(parser), do: Path.join(directory(parser), script())
+  defp script_destination(parser), do: Path.join(parser.path, script())
 end

--- a/apps/parsers/mix/lib/mix/tasks/mix.parse.ex
+++ b/apps/parsers/mix/lib/mix/tasks/mix.parse.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Mix.Parse do
   use Mix.Task
 
-  @shortdoc "Parse arbitrary mix.exs and return the list of top-level dependencies defined in it."
-  def run([path]) do
-    File.read!(path)
+  @shortdoc "Parse arbitrary mix.exs file and return the list of top-level dependencies defined in it."
+  def run([id]) do
+    id
     |> S12y.Parsers.Mix.parse()
     |> IO.puts()
   end

--- a/apps/parsers/mix/test/mix_test.exs
+++ b/apps/parsers/mix/test/mix_test.exs
@@ -5,10 +5,14 @@ defmodule S12y.Parsers.MixTest do
   alias S12y.Parsers
 
   generate do
-    test "parse input into output", %{fixture: fixture} do
-      {:ok, input} = read_input(fixture)
+    setup %{fixture: fixture} do
+      {:ok, input} = prepare_input(fixture)
       {:ok, output} = read_output(fixture)
 
+      %{input: input, output: output}
+    end
+
+    test "parse input into output", %{input: input, output: output} do
       parsed = Parsers.Mix.parse(input)
 
       assert Jason.decode!(parsed) == Jason.decode!(output)

--- a/apps/parsers/mix/test/support/fixtures.ex
+++ b/apps/parsers/mix/test/support/fixtures.ex
@@ -24,12 +24,23 @@ defmodule S12y.Parsers.Fixtures do
     end)
   end
 
-  def read_input(fixture), do: read_fixture(fixture, "input")
-  def read_output(fixture), do: read_fixture(fixture, "output")
+  def prepare_input(fixture) do
+    id = UUID.uuid4()
 
-  defp read_fixture(fixture, filename) do
-    "#{fixture}/#{filename}"
-    |> Path.expand(@fixtures_path)
-    |> File.read()
+    fixture |> input_path |> File.copy!("#{tmp_path(id)}/mix.exs")
+
+    {:ok, id}
+  end
+
+  def read_input(fixture), do: fixture |> input_path |> File.read()
+  def read_output(fixture), do: fixture |> output_path |> File.read()
+
+  def input_path(fixture), do: "#{fixture}/input" |> Path.expand(@fixtures_path)
+  def output_path(fixture), do: "#{fixture}/output" |> Path.expand(@fixtures_path)
+
+  defp tmp_path(path) do
+    path = Path.join("/tmp", path)
+    File.mkdir_p!(path)
+    path
   end
 end


### PR DESCRIPTION
each uploaded project are assigned a uuid, so subsequent works for parsing it can be based of it, which would makes passing around data easier, since we'll only need to pass in a single data (uuid) instead of the whole uploaded file and configuration