### PR TITLE
Attempt#1: Setup Parsers Worker App

### DIFF
--- a/apps/parsers/worker/.formatter.exs
+++ b/apps/parsers/worker/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/apps/parsers/worker/.gitignore
+++ b/apps/parsers/worker/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+worker-*.tar
+

--- a/apps/parsers/worker/README.md
+++ b/apps/parsers/worker/README.md
@@ -1,0 +1,21 @@
+# Worker
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `worker` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:worker, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/worker](https://hexdocs.pm/worker).
+

--- a/apps/parsers/worker/config/config.exs
+++ b/apps/parsers/worker/config/config.exs
@@ -1,0 +1,10 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Config module.
+#
+# This configuration file is loaded before any dependency and
+# is restricted to this project.
+
+# General application configuration
+import Config
+
+import_config Path.expand("../../../s12y/config/config.exs", __DIR__)

--- a/apps/parsers/worker/lib/worker.ex
+++ b/apps/parsers/worker/lib/worker.ex
@@ -1,0 +1,7 @@
+defmodule S12y.Parsers.Worker do
+  alias S12y.Parsers.Worker
+
+  def parse(project) do
+    Worker.Runtime.parse(project)
+  end
+end

--- a/apps/parsers/worker/lib/worker/application.ex
+++ b/apps/parsers/worker/lib/worker/application.ex
@@ -1,0 +1,10 @@
+defmodule S12y.Parsers.Worker.Application do
+  use Application
+
+  alias S12y.Parsers.Worker
+
+  @impl true
+  def start(_type, _args) do
+    Worker.Supervisor.start_link(name: Worker.Supervisor)
+  end
+end

--- a/apps/parsers/worker/lib/worker/registry.ex
+++ b/apps/parsers/worker/lib/worker/registry.ex
@@ -1,0 +1,58 @@
+defmodule S12y.Parsers.Worker.Registry do
+  alias S12y.Parsers.Worker
+
+  @doc """
+  Specify how the registry should be starts.
+  """
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [Keyword.merge(opts, keys: :unique)]},
+      type: :supervisor
+    }
+  end
+
+  @doc """
+  Starts the registry.
+  """
+  def start_link(opts) do
+    Registry.start_link(opts)
+  end
+
+  @doc """
+  Ensures there is a child process associated with the given project.
+  """
+  def start_child(server, project) do
+    case lookup(server, project) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      :error ->
+        via = {:via, Registry, {server, project.id}}
+
+        DynamicSupervisor.start_child(
+          Worker.RuntimeSupervisor,
+          %{
+            id: Worker.Runtime,
+            start: {Worker.Runtime, :start_link, [[name: via, project: project]]},
+            restart: :temporary
+          }
+        )
+    end
+  end
+
+  @doc """
+  Looks up the child process's pid associated with the given project.
+
+  Returns `{:ok, pid}` if the process exists, `:error` otherwise.
+  """
+  def lookup(server, project) do
+    case Registry.lookup(server, project.id) do
+      [{pid, nil}] ->
+        {:ok, pid}
+
+      _ ->
+        :error
+    end
+  end
+end

--- a/apps/parsers/worker/lib/worker/runtime.ex
+++ b/apps/parsers/worker/lib/worker/runtime.ex
@@ -1,0 +1,34 @@
+defmodule S12y.Parsers.Worker.Runtime do
+  use GenServer
+
+  alias S12y.Parsers.Worker
+
+  # Client
+
+  def start_link(args) do
+    project = Keyword.get(args, :project)
+
+    GenServer.start_link(__MODULE__, project, args)
+  end
+
+  def parse(project) do
+    {:ok, runtime} = Worker.Registry.start_child(Worker.Registry, project)
+
+    # TODO: given that we want it to do one thing, should we use Task instead of GenServer? how to isolate crashed Task?
+    result = GenServer.call(runtime, {:parse})
+    GenServer.stop(runtime)
+    result
+  end
+
+  # Server
+
+  @impl true
+  def init(project) do
+    {:ok, %{project: project}}
+  end
+
+  @impl true
+  def handle_call({:parse}, _from, %{project: project} = state) do
+    {:reply, {:ok, project}, state}
+  end
+end

--- a/apps/parsers/worker/lib/worker/supervisor.ex
+++ b/apps/parsers/worker/lib/worker/supervisor.ex
@@ -1,0 +1,19 @@
+defmodule S12y.Parsers.Worker.Supervisor do
+  use Supervisor
+
+  alias S12y.Parsers.Worker
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, :ok, opts)
+  end
+
+  @impl true
+  def init(:ok) do
+    children = [
+      {DynamicSupervisor, name: Worker.RuntimeSupervisor, strategy: :one_for_one},
+      {Worker.Registry, name: Worker.Registry}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/apps/parsers/worker/mix.exs
+++ b/apps/parsers/worker/mix.exs
@@ -1,0 +1,33 @@
+defmodule S12y.Parsers.Worker.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :s12y_parsers_worker,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {S12y.Parsers.Worker.Application, []}
+    ]
+  end
+
+  # Specifies which paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:s12y, path: Path.expand("../../s12y", __DIR__)}
+    ]
+  end
+end

--- a/apps/parsers/worker/mix.lock
+++ b/apps/parsers/worker/mix.lock
@@ -1,0 +1,9 @@
+%{
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "db_connection": {:hex, :db_connection, "2.1.1", "a51e8a2ee54ef2ae6ec41a668c85787ed40cb8944928c191280fe34c15b76ae5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "3.2.2", "bb6d1dbcd7ef975b60637e63182e56f3d7d0b5dd9c46d4b9d6183a5c455d65d1", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto_sql": {:hex, :ecto_sql, "3.2.0", "751cea597e8deb616084894dd75cbabfdbe7255ff01e8c058ca13f0353a3921b", [:mix], [{:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.2.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:myxql, "~> 0.2.0", [hex: :myxql, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.15.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
+}

--- a/apps/parsers/worker/test/test_helper.exs
+++ b/apps/parsers/worker/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/parsers/worker/test/worker/registry_test.exs
+++ b/apps/parsers/worker/test/worker/registry_test.exs
@@ -1,0 +1,50 @@
+defmodule S12y.Parsers.Worker.RegistryTest do
+  use ExUnit.Case, async: true
+  import S12y.Fixture
+
+  alias S12y.Parsers.Worker
+
+  describe "Worker.Registry" do
+    setup context do
+      start_supervised!({Worker.Registry, name: context.test})
+      project = project_fixture()
+
+      %{registry: context.test, project: project}
+    end
+
+    test "spawns worker runtime", %{registry: registry, project: project} do
+      assert Worker.Registry.lookup(registry, project) == :error
+
+      Worker.Registry.start_child(registry, project)
+      assert {:ok, runtime} = Worker.Registry.lookup(registry, project)
+
+      # TODO: not sure if introspecting Process.info is a good thing?
+      assert Process.info(runtime)[:dictionary][:"$initial_call"] == {Worker.Runtime, :init, 1}
+    end
+
+    test "removes runtimes on exit", %{registry: registry, project: project} do
+      Worker.Registry.start_child(registry, project)
+      {:ok, runtime} = Worker.Registry.lookup(registry, project)
+
+      stop_runtime!(registry, runtime)
+
+      assert Worker.Registry.lookup(registry, project) == :error
+    end
+
+    test "removes runtime on crash", %{registry: registry, project: project} do
+      Worker.Registry.start_child(registry, project)
+      {:ok, runtime} = Worker.Registry.lookup(registry, project)
+
+      stop_runtime!(registry, runtime, :shutdown)
+
+      assert Worker.Registry.lookup(registry, project) == :error
+    end
+
+    def stop_runtime!(registry, runtime, reason \\ :normal, timeout \\ :infinity) do
+      GenServer.stop(runtime, reason, timeout)
+
+      # ensure the registry processed the DOWN message
+      Worker.Registry.start_child(registry, %{id: "404"})
+    end
+  end
+end

--- a/apps/parsers/worker/test/worker/runtime_test.exs
+++ b/apps/parsers/worker/test/worker/runtime_test.exs
@@ -1,0 +1,3 @@
+defmodule S12y.Parsers.Worker.RuntimeTest do
+  use ExUnit.Case, async: true
+end

--- a/apps/parsers/worker/test/worker_test.exs
+++ b/apps/parsers/worker/test/worker_test.exs
@@ -1,0 +1,18 @@
+defmodule S12y.Parsers.WorkerTest do
+  use ExUnit.Case, async: true
+  import S12y.Fixture
+
+  alias S12y.Parsers.Worker
+
+  describe "Worker.Registry" do
+    setup do
+      project = project_fixture()
+
+      %{project: project}
+    end
+
+    test "parse runs", %{project: project} do
+      assert {:ok, _} = Worker.parse(project)
+    end
+  end
+end


### PR DESCRIPTION
the worker supervision tree doesn't feel quite right, each parsing job only need to parse a single project, so maybe we should use Task (one time) instead of GenServer (long running)

but, Task will crash the caller, we don't want that

ultimately, the worker app will be included as part of web, and we want parsing job to run asynchronously of web request, so that we'll be able to respond to user request ASAP