### PR TITLE
potential fix for race condition

### DIFF
--- a/apps/cli/lib/cli.ex
+++ b/apps/cli/lib/cli.ex
@@ -1,10 +1,8 @@
 defmodule S12y.CLI do
   @parsers_path Path.expand("../../parsers", __DIR__)
 
-  def run(path, args) do
-    {:ok, cwd} = File.cwd()
-
-    case System.cmd("sh", ["#{cwd}/#{path}" | args]) do
+  def run(path, args, opts \\ []) do
+    case System.cmd("sh", [path | args], opts) do
       {result, 0} ->
         {:ok, result}
 
@@ -13,18 +11,7 @@ defmodule S12y.CLI do
     end
   end
 
-  def change_path(path, callback) do
-    {:ok, cwd} = File.cwd()
-
-    try do
-      :ok = File.mkdir_p(path)
-      :ok = File.cd(path)
-      callback.()
-    after
-      File.cd(cwd)
-    end
-  end
-
   def parsers_path, do: @parsers_path
   def parser_path(parser), do: Path.expand(parser, @parsers_path)
+  def parser_path(parser, path), do: Path.expand(path, parser_path(parser))
 end

--- a/apps/cli/test/cli_test.exs
+++ b/apps/cli/test/cli_test.exs
@@ -4,22 +4,8 @@ defmodule S12y.CLITest do
   alias S12y.CLI
 
   test "run allows running arbitrary sh script" do
-    CLI.change_path("test/support", fn ->
-      assert {:ok, "ping\n"} == CLI.run("echo.sh", ["ping"])
-    end)
-  end
+    script = Path.expand("support/echo.sh", __DIR__)
 
-  test "change_path temporarily changed the working directly" do
-    {:ok, cwd_before} = File.cwd()
-
-    CLI.change_path("test/support", fn ->
-      {:ok, cwd_during} = File.cwd()
-
-      assert "#{cwd_before}/test/support" == cwd_during
-    end)
-
-    {:ok, cwd_after} = File.cwd()
-
-    assert cwd_before == cwd_after
+    assert {:ok, "ping\n"} == CLI.run(script, ["ping"])
   end
 end


### PR DESCRIPTION
there seems to be a race condition between File.cwd and File.cd, where File.cwd will return the path before File.cd is executed, resulting in parser file being written into the worker directory (e.g. overriding worker own mix.exs) instead of into the project designated tmp directory